### PR TITLE
feat: add Makefile and container support

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,38 @@
+# Use Python 3.12 slim as base image
+FROM python:3.12-slim
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    DEBIAN_FRONTEND=noninteractive
+
+# Set work directory
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install uv for package management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Copy requirements file
+COPY requirements.txt .
+
+# Install Python dependencies
+RUN /root/.cargo/bin/uv pip install --system -r requirements.txt
+
+# Copy project files
+COPY . .
+
+# Collect static files
+RUN python manage.py collectstatic --noinput
+
+# Expose port
+EXPOSE 8000
+
+# Run migrations and start server
+CMD python manage.py migrate && \
+    python manage.py runserver 0.0.0.0:8000

--- a/Makefile
+++ b/Makefile
@@ -3,48 +3,75 @@
 .PHONY: help server sync migrate shell createsuperuser test clean
 
 help:
-	@echo "Available commands:"
-	@echo "  make server      - Run development server"
-	@echo "  make sync        - Run uv sync to update dependencies"
-	@echo "  make migrate     - Run database migrations"
-	@echo "  make shell       - Start Django shell"
-	@echo "  make test        - Run tests"
-	@echo "  make clean       - Remove Python bytecode files and cache"
-	@echo "  make createsuperuser - Create a superuser"
+        @echo "Available commands:"
+        @echo "  make server      - Run development server"
+        @echo "  make sync        - Run uv sync to update dependencies"
+        @echo "  make migrate     - Run database migrations"
+        @echo "  make shell       - Start Django shell"
+        @echo "  make test        - Run tests"
+        @echo "  make clean       - Remove Python bytecode files and cache"
+        @echo "  make createsuperuser - Create a superuser"
 
 server:
-	uv run manage.py runserver 0.0.0.0:53324
+        uv run manage.py runserver 0.0.0.0:53324
 
 sync:
-	uv sync
+        uv sync
 
 migrate:
-	uv run manage.py migrate
+        uv run manage.py migrate
 
 shell:
-	uv run manage.py shell
+        uv run manage.py shell
 
 test:
-	uv run manage.py test
+        uv run manage.py test
 
 clean:
-	find . -type f -name "*.pyc" -delete
-	find . -type d -name "__pycache__" -delete
-	find . -type d -name ".pytest_cache" -delete
+        find . -type f -name "*.pyc" -delete
+        find . -type d -name "__pycache__" -delete
+        find . -type d -name ".pytest_cache" -delete
 
 createsuperuser:
-	uv run manage.py createsuperuser
+        uv run manage.py createsuperuser
 
 # Add migrations command to create new migrations
 makemigrations:
-	uv run manage.py makemigrations
+        uv run manage.py makemigrations
 
 # Add a command to collect static files
 collectstatic:
-	uv run manage.py collectstatic --noinput
+        uv run manage.py collectstatic --noinput
 
 # Add a command to run both makemigrations and migrate
 migrateall: makemigrations migrate
 
 # Add a command to start fresh (clean and sync)
 fresh: clean sync
+
+# Container related commands
+.PHONY: container-build container-run container-stop
+
+CONTAINER_NAME = musicevents
+CONTAINER_TAG = latest
+CONTAINER_PORT = 8000
+
+container-build:
+        podman build -t $(CONTAINER_NAME):$(CONTAINER_TAG) -f Containerfile .
+
+container-run:
+        podman run --name $(CONTAINER_NAME) \
+                -p $(CONTAINER_PORT):8000 \
+                -v $(PWD)/media:/app/media \
+                -d $(CONTAINER_NAME):$(CONTAINER_TAG)
+
+container-stop:
+        -podman stop $(CONTAINER_NAME)
+        -podman rm $(CONTAINER_NAME)
+
+# Run all container commands in sequence
+container-all: container-stop container-build container-run
+
+# Show container logs
+container-logs:
+        podman logs -f $(CONTAINER_NAME)


### PR DESCRIPTION
This PR adds development tooling improvements:

### Makefile
- Add common development commands:
  - `make server`: Run development server
  - `make sync`: Update dependencies
  - `make migrate`: Run database migrations
  - `make shell`: Start Django shell
  - `make test`: Run tests
  - `make clean`: Remove Python bytecode files
  - Additional commands for migrations and static files

### Container Support
- Add Containerfile for containerized deployment
- Add container-related make targets:
  - `make container-build`: Build the container image
  - `make container-run`: Run the container
  - `make container-stop`: Stop and remove the container
  - `make container-all`: Run all container commands
  - `make container-logs`: Show container logs
- Use podman for container management
- Mount media directory for persistent storage