### PR TITLE
Move sync buttons to admin changelist view

### DIFF
--- a/events/admin.py
+++ b/events/admin.py
@@ -48,7 +48,7 @@ class EventAdmin(admin.ModelAdmin):
     date_hierarchy = 'date'
     filter_horizontal = ('artists',)
     readonly_fields = ('external_id',)
-    actions = ['sync_ticketmaster', 'sync_riviera']
+    change_list_template = 'admin/events/event/change_list.html'
     
     def display_artists(self, obj):
         return ", ".join([artist.name for artist in obj.artists.all()[:3]])
@@ -93,13 +93,7 @@ class EventAdmin(admin.ModelAdmin):
         
         return render(request, 'admin/events/event/riviera_sync.html', {})
     
-    def sync_ticketmaster(self, request, queryset):
-        return redirect('admin:ticketmaster_sync')
-    sync_ticketmaster.short_description = "Sync events from Ticketmaster"
-    
-    def sync_riviera(self, request, queryset):
-        return redirect('admin:riviera_sync')
-    sync_riviera.short_description = "Sync events from Sala Riviera"
+
 
 
 # Register with the default admin site

--- a/events/templates/admin/events/event/change_list.html
+++ b/events/templates/admin/events/event/change_list.html
@@ -1,0 +1,16 @@
+{% extends "admin/change_list.html" %}
+{% load i18n admin_urls %}
+
+{% block object-tools-items %}
+    <li>
+        <a href="{% url 'admin:ticketmaster_sync' %}" class="addlink">
+            {% trans 'Sync Ticketmaster Events' %}
+        </a>
+    </li>
+    <li>
+        <a href="{% url 'admin:riviera_sync' %}" class="addlink">
+            {% trans 'Sync Riviera Events' %}
+        </a>
+    </li>
+    {{ block.super }}
+{% endblock %}


### PR DESCRIPTION
This PR improves the sync functionality in the Django admin by moving the sync buttons to a more accessible location.

Changes:
- Remove sync actions from dropdown (they required event selection)
- Add sync buttons to the top of the Event changelist view
- Buttons are always visible and do not require event selection

The sync buttons now appear at the top of the Event list page in the admin interface, next to the "Add Event" button. This is a more intuitive location since syncing events is a global action that does not need to operate on selected events.

Both sync forms maintain the same functionality but are now more accessible from the admin interface.