### PR TITLE
Add PostgreSQL database and configure production container

### DIFF
--- a/Containerfile.prod
+++ b/Containerfile.prod
@@ -37,6 +37,9 @@ RUN groupadd -r django && useradd -r -g django -d /app django
 COPY --from=builder /app /app
 COPY --from=builder /.venv /.venv
 
+RUN mkdir -p /app/staticfiles
+RUN chown django:django /app/staticfiles
+
 WORKDIR /app
 
 # put the env binaries first on PATH

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,10 +22,14 @@ services:
       - CORS_ALLOWED_ORIGINS=http://localhost:8001
       - DJANGO_SECURE_SSL_REDIRECT=False
     volumes:
-      - ./media:/app/media
-      - ./static:/app/static
+      - django_media:/app/media
+      - django_staticfiles:/app/staticfiles
     depends_on:
       - db
+    command: >
+      bash -c "/.venv/bin/python3 manage.py migrate --noinput &&
+               /.venv/bin/python3 manage.py collectstatic --noinput &&
+               gunicorn music_events_project.wsgi:application --bind 0.0.0.0:8000 --workers 3 --threads 4 --timeout 30 --preload"
 
   db:
     image: postgres:15
@@ -40,3 +44,5 @@ services:
 
 volumes:
   postgres_data:
+  django_staticfiles:
+  django_media:

--- a/music_events_project/settings/prod.py
+++ b/music_events_project/settings/prod.py
@@ -47,3 +47,7 @@ SECURE_CONTENT_TYPE_NOSNIFF = True
 SECURE_HSTS_SECONDS = 31536000  # 1 year
 SECURE_HSTS_INCLUDE_SUBDOMAINS = True
 SECURE_HSTS_PRELOAD = True
+
+MIDDLEWARE += [
+    'whitenoise.middleware.WhiteNoiseMiddleware',  # or whatever you need
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "requests>=2.32.3",
     "ruff>=0.11.6",
     "setuptools>=79.0.0",
+    "whitenoise>=6.9.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -303,6 +303,7 @@ dependencies = [
     { name = "requests" },
     { name = "ruff" },
     { name = "setuptools" },
+    { name = "whitenoise" },
 ]
 
 [package.optional-dependencies]
@@ -329,6 +330,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.3" },
     { name = "ruff", specifier = ">=0.11.6" },
     { name = "setuptools", specifier = ">=79.0.0" },
+    { name = "whitenoise", specifier = ">=6.9.0" },
 ]
 provides-extras = ["dev"]
 
@@ -645,4 +647,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166 },
+]
+
+[[package]]
+name = "whitenoise"
+version = "6.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/cf/c15c2f21aee6b22a9f6fc9be3f7e477e2442ec22848273db7f4eb73d6162/whitenoise-6.9.0.tar.gz", hash = "sha256:8c4a7c9d384694990c26f3047e118c691557481d624f069b7f7752a2f735d609", size = 25920 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b2/2ce9263149fbde9701d352bda24ea1362c154e196d2fda2201f18fc585d7/whitenoise-6.9.0-py3-none-any.whl", hash = "sha256:c8a489049b7ee9889617bb4c274a153f3d979e8f51d2efd0f5b403caf41c57df", size = 20161 },
 ]


### PR DESCRIPTION
This PR adds a PostgreSQL database service to the Docker Compose configuration and configures the production container with the necessary environment variables to connect to the database. It also sets DJANGO_ALLOWED_HOSTS and ALLOWED_HOSTS to enable localhost access.