### PR TITLE
Update Helm charts and GitHub workflow

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,12 +1,16 @@
-name: Build and Push Multi-Architecture Container
+name: Build and Push Multi-Architecture Container and Helm Charts
 
 on:
   push:
     branches: [ main ]
+    tags:
+      - 'v*'
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: mangelajo/music-events
+  CHART_REGISTRY: ghcr.io/mangelajo/charts
 
 jobs:
   build-and-push:
@@ -14,10 +18,29 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      SHA_TAG: ${{ steps.save-tag.outputs.SHA_TAG }}
+      VERSION: ${{ steps.get_version.outputs.VERSION }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get version
+        id: get_version
+        run: |
+          if [[ $GITHUB_REF == refs/tags/v* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
+          elif [[ $GITHUB_REF == refs/heads/main ]]; then
+            TIMESTAMP=$(date +%s)
+            VERSION="0.0.0-main-${TIMESTAMP}"
+          else
+            VERSION=$(git rev-parse --short HEAD)
+          fi
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Determined version: $VERSION"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -40,6 +63,7 @@ jobs:
           tags: |
             type=sha,format=short
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ steps.get_version.outputs.VERSION }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
@@ -52,3 +76,67 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          
+      - name: Save image tag for Helm chart
+        id: save-tag
+        run: |
+          # Extract the SHA tag
+          SHA_TAG=$(echo "${{ steps.meta.outputs.tags }}" | grep -o "sha-[a-f0-9]*" | head -1)
+          echo "SHA_TAG=${SHA_TAG}" >> $GITHUB_OUTPUT
+          echo "SHA_TAG=${SHA_TAG}" >> $GITHUB_ENV
+          
+  push-helm-charts:
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    permissions:
+      contents: read
+      packages: write
+    env:
+      SHA_TAG: ${{ needs.build-and-push.outputs.SHA_TAG }}
+      VERSION: ${{ needs.build-and-push.outputs.VERSION }}
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+        
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: 'latest'
+          
+      - name: Configure Git
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Update Chart Version and Package
+        run: |
+          # Update Chart.yaml with the version
+          sed -i "s/version: 0.1.0/version: ${{ env.VERSION }}/" ./charts/musicevents/Chart.yaml
+          sed -i "s/appVersion: \"1.0.0\"/appVersion: \"${{ env.VERSION }}\"/" ./charts/musicevents/Chart.yaml
+          
+          # Update the Helm chart with the latest image tag
+          if [ -n "${{ needs.build-and-push.outputs.SHA_TAG }}" ]; then
+            sed -i "s/tag: latest/tag: ${{ needs.build-and-push.outputs.SHA_TAG }}/g" ./charts/musicevents/values.yaml
+            echo "Updated Helm chart to use image tag: ${{ needs.build-and-push.outputs.SHA_TAG }}"
+          else
+            echo "No SHA tag found, using default tag"
+          fi
+          
+          # Create directory for chart packages
+          mkdir -p .cr-release-packages
+          
+          # Package the chart
+          helm package ./charts/musicevents --destination .cr-release-packages
+          
+          # Push to OCI registry
+          helm push .cr-release-packages/musicevents-${{ env.VERSION }}.tgz oci://${{ env.CHART_REGISTRY }}

--- a/charts/musicevents/Chart.yaml
+++ b/charts/musicevents/Chart.yaml
@@ -15,3 +15,4 @@ keywords:
   - music
   - events
   - ticketmaster
+  - spotify

--- a/charts/musicevents/templates/deployment.yaml
+++ b/charts/musicevents/templates/deployment.yaml
@@ -27,6 +27,10 @@ spec:
       serviceAccountName: {{ include "musicevents.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: wait-for-db
+          image: busybox
+          command: ['sh', '-c', 'until nc -z {{ include "musicevents.fullname" . }}-postgres 5432; do echo waiting for postgres; sleep 2; done;']
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -48,6 +52,62 @@ spec:
               value: {{ .Values.djangoDebug | quote }}
             - name: DJANGO_ALLOWED_HOSTS
               value: {{ .Values.domain | quote }}
+            - name: SPOTIFY_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "musicevents.fullname" . }}
+                  key: spotify-client-id
+            - name: SPOTIFY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "musicevents.fullname" . }}
+                  key: spotify-client-secret
+            - name: DJANGO_SETTINGS_MODULE
+              value: {{ .Values.djangoSettingsModule | quote }}
+            - name: DJANGO_SECURE_SSL_REDIRECT
+              value: {{ .Values.djangoSecureSslRedirect | quote }}
+            - name: CORS_ALLOWED_ORIGINS
+              value: {{ .Values.corsAllowedOrigins | default (printf "https://%s" .Values.domain) | quote }}
+            - name: ALLOWED_HOSTS
+              value: {{ .Values.domain | quote }}
+              
+            # Database configuration
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "musicevents.fullname" . }}
+                  key: postgres-db
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "musicevents.fullname" . }}
+                  key: postgres-user
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "musicevents.fullname" . }}
+                  key: postgres-password
+            - name: POSTGRES_HOST
+              value: {{ include "musicevents.fullname" . }}-postgres
+            - name: POSTGRES_PORT
+              value: {{ .Values.database.port | quote }}
+              
+            # Admin configuration
+            - name: ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "musicevents.fullname" . }}
+                  key: admin-username
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "musicevents.fullname" . }}
+                  key: admin-password
+            - name: ADMIN_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "musicevents.fullname" . }}
+                  key: admin-email
           ports:
             - name: http
               containerPort: 8000
@@ -69,6 +129,14 @@ spec:
           volumeMounts:
             - name: media
               mountPath: /app/media
+          command:
+            - /bin/bash
+            - -c
+            - |
+              /.venv/bin/python3 manage.py migrate --noinput
+              /.venv/bin/python3 manage.py collectstatic --noinput
+              /.venv/bin/python3 manage.py ensure_admin
+              gunicorn music_events_project.wsgi:application --bind 0.0.0.0:8000 --workers 3 --threads 4 --timeout 30 --preload --log-level debug --enable-stdio-inheritance --capture-output --access-logfile -
       volumes:
         - name: media
           {{- if .Values.persistence.enabled }}

--- a/charts/musicevents/templates/postgres-deployment.yaml
+++ b/charts/musicevents/templates/postgres-deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "musicevents.fullname" . }}-postgres
+  labels:
+    {{- include "musicevents.labels" . | nindent 4 }}
+    app.kubernetes.io/component: database
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "musicevents.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: database
+  template:
+    metadata:
+      labels:
+        {{- include "musicevents.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: database
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "musicevents.fullname" . }}
+                  key: postgres-db
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "musicevents.fullname" . }}
+                  key: postgres-user
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "musicevents.fullname" . }}
+                  key: postgres-password
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+      volumes:
+        - name: postgres-data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "musicevents.fullname" . }}-postgres-data
+          {{- else }}
+          emptyDir: {}
+          {{- end }}

--- a/charts/musicevents/templates/postgres-pvc.yaml
+++ b/charts/musicevents/templates/postgres-pvc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "musicevents.fullname" . }}-postgres-data
+  labels:
+    {{- include "musicevents.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.persistence.postgres.storageClass }}
+  storageClassName: {{ .Values.persistence.postgres.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.postgres.size }}
+{{- end }}

--- a/charts/musicevents/templates/postgres-service.yaml
+++ b/charts/musicevents/templates/postgres-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "musicevents.fullname" . }}-postgres
+  labels:
+    {{- include "musicevents.labels" . | nindent 4 }}
+    app.kubernetes.io/component: database
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5432
+      targetPort: postgres
+      protocol: TCP
+      name: postgres
+  selector:
+    {{- include "musicevents.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: database

--- a/charts/musicevents/templates/secret.yaml
+++ b/charts/musicevents/templates/secret.yaml
@@ -8,3 +8,15 @@ type: Opaque
 data:
   ticketmaster-api-key: {{ .Values.ticketmasterApiKey | b64enc | quote }}
   django-secret-key: {{ .Values.djangoSecretKey | default (randAlphaNum 32) | b64enc | quote }}
+  spotify-client-id: {{ .Values.spotifyClientId | b64enc | quote }}
+  spotify-client-secret: {{ .Values.spotifyClientSecret | b64enc | quote }}
+  
+  # Database credentials
+  postgres-db: {{ .Values.database.name | b64enc | quote }}
+  postgres-user: {{ .Values.database.user | b64enc | quote }}
+  postgres-password: {{ .Values.database.password | b64enc | quote }}
+  
+  # Admin credentials
+  admin-username: {{ .Values.adminUsername | b64enc | quote }}
+  admin-password: {{ .Values.adminPassword | b64enc | quote }}
+  admin-email: {{ .Values.adminEmail | b64enc | quote }}

--- a/charts/musicevents/values.yaml
+++ b/charts/musicevents/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 
 image:
-  repository: musicevents
+  repository: ghcr.io/mangelajo/music-events
   tag: latest
   pullPolicy: IfNotPresent
 
@@ -52,6 +52,24 @@ domain: musicevents.local
 ticketmasterApiKey: ""
 djangoSecretKey: ""
 djangoDebug: "False"
+spotifyClientId: ""
+spotifyClientSecret: ""
+djangoSettingsModule: "music_events_project.settings.prod"
+djangoSecureSslRedirect: "False"
+corsAllowedOrigins: ""
+
+# Admin configuration
+adminUsername: "admin"
+adminPassword: "admin"
+adminEmail: "admin@example.com"
+
+# Database configuration
+database:
+  host: "postgres-service"
+  port: "5432"
+  name: "musicevents"
+  user: "musicevents"
+  password: "musicevents"
 
 service:
   type: ClusterIP
@@ -87,6 +105,10 @@ persistence:
     storageClass: ""
     accessMode: ReadWriteOnce
     size: 1Gi
+  postgres:
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    size: 5Gi
 
 # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:


### PR DESCRIPTION
## Changes

- Add Spotify client ID and secret to Helm charts and secrets
- Add PostgreSQL database deployment, service, and PVC to Helm charts
- Update GitHub workflow to push Helm charts to GHCR
- Implement versioning for Helm charts with timestamp for main branch (0.0.0-main-timestamp format)
- Update image repository in Helm values to match the GitHub container registry
- Add init container to wait for database to be ready
- Update command in deployment to match docker-compose.yml

This PR aligns the Helm charts with the docker-compose.yml configuration and adds proper versioning for the Helm charts.